### PR TITLE
ci(gha): implement linting with ruff and testing with pytest

### DIFF
--- a/.github/workflows/backend-tests.yaml
+++ b/.github/workflows/backend-tests.yaml
@@ -47,3 +47,7 @@ jobs:
         run: |
           uv run ruff check --output-format=github --target-version=py313 src tests
           uv run ruff format --diff --check --target-version=py313 src tests
+
+      - name: Run Backend Tests
+        run: |
+          uv run pytest

--- a/.github/workflows/backend-tests.yaml
+++ b/.github/workflows/backend-tests.yaml
@@ -1,0 +1,49 @@
+name: Backend Tests
+
+on:
+  pull_request:
+
+jobs:
+  check_paths:
+    runs-on: ubuntu-latest
+
+    outputs:
+      should_run: ${{ steps.filter.outputs.backend }}
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3.0.2
+        id: filter
+        with:
+          filters: |
+            backend:
+              - 'src/backend/**'
+              - '.github/workflows/backend-tests.yaml'
+
+  test:
+    name: Test Backend
+    needs: check_paths
+    if: ${{ needs.check_paths.outputs.should_run == 'true' }}
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./src/backend
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install UV
+        uses: astral-sh/setup-uv@v5
+
+      - name: Set up Python
+        run: uv python install
+
+      - name: Install dependencies
+        run: |
+          uv sync --locked --dev
+
+      - name: Lint with Ruff
+        run: |
+          uv run ruff check --output-format=github --target-version=py313 src tests
+          uv run ruff format --diff --check --target-version=py313 src tests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,3 +4,11 @@ repos:
     hooks:
       - id: commitizen
         stages: [commit-msg]
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version.
+    rev: v0.11.7
+    hooks:
+      # Run the linter.
+      - id: ruff
+      # Run the formatter.
+      - id: ruff-format

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,7 @@
 [tools]
 pre-commit = "latest"
 python = "3.13"
+ruff = "latest"
 trivy = "latest"
 uv = "latest"
 

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -6,14 +6,19 @@ readme = "README.md"
 authors = [{ name = "Mischa van den Burg", email = "mischa@gmail.com" }]
 requires-python = ">=3.13"
 dependencies = [
-    "fastapi>=0.115.12",
- "httpx>=0.28.1",
- "ruff>=0.11.8",
- "uvicorn>=0.34.2",
+  "fastapi>=0.115.12",
+  "httpx>=0.28.1",
+  "pytest>=8.3.5",
+  "pytest-asyncio>=0.26.0",
+  "ruff>=0.11.8",
+  "uvicorn>=0.34.2",
 ]
 
 [project.scripts]
 study-tracker-api = "backend.main:main"
+
+[tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "function"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/backend"]

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -5,7 +5,12 @@ description = "Backend API for tracking study time for DevOps certifications"
 readme = "README.md"
 authors = [{ name = "Mischa van den Burg", email = "mischa@gmail.com" }]
 requires-python = ">=3.13"
-dependencies = ["fastapi>=0.115.12", "httpx>=0.28.1", "uvicorn>=0.34.2"]
+dependencies = [
+    "fastapi>=0.115.12",
+ "httpx>=0.28.1",
+ "ruff>=0.11.8",
+ "uvicorn>=0.34.2",
+]
 
 [project.scripts]
 study-tracker-api = "backend.main:main"

--- a/src/backend/tests/test_config.py
+++ b/src/backend/tests/test_config.py
@@ -1,0 +1,69 @@
+import os
+from unittest import mock
+
+from backend.config import (
+    APP_NAME,
+    API_HOST,
+    API_PORT,
+    DATA_DIR,
+    CORS_ALLOW_ORIGINS,
+    CORS_ALLOW_METHODS,
+    CORS_ALLOW_HEADERS,
+    CORS_ALLOW_CREDENTIALS,
+)
+
+
+def test_settings_default_values():
+    """Test that Settings has the expected default values."""
+    assert APP_NAME == "DevOps Study Tracker"
+    assert API_HOST == "0.0.0.0"
+    assert API_PORT == 22112
+    assert DATA_DIR.endswith("data")
+
+    # Test CORS default values
+    assert CORS_ALLOW_ORIGINS == ["*"]
+    assert CORS_ALLOW_METHODS == ["*"]
+    assert CORS_ALLOW_HEADERS == ["*"]
+    assert CORS_ALLOW_CREDENTIALS is True
+
+
+@mock.patch.dict(
+    os.environ,
+    {
+        "API_HOST": "127.0.0.1",
+        "API_PORT": "9000",
+        "CORS_ALLOW_ORIGINS": "https://example.com,https://api.example.com",
+        "CORS_ALLOW_METHODS": "GET,POST,PUT",
+        "CORS_ALLOW_HEADERS": "Content-Type,Authorization",
+        "CORS_ALLOW_CREDENTIALS": "false",
+    },
+)
+def test_settings_from_env():
+    """Test that Settings loads values from environment variables."""
+    # Force reload of the config module to get updated environment variables
+    import importlib
+    import backend.config
+
+    importlib.reload(backend.config)
+
+    # Import the settings again after reload
+    from backend.config import (
+        API_HOST,
+        API_PORT,
+        CORS_ALLOW_ORIGINS,
+        CORS_ALLOW_METHODS,
+        CORS_ALLOW_HEADERS,
+        CORS_ALLOW_CREDENTIALS,
+    )
+
+    assert API_HOST == "127.0.0.1"
+    assert API_PORT == 9000
+
+    # Test CORS values from environment
+    assert CORS_ALLOW_ORIGINS == [
+        "https://example.com",
+        "https://api.example.com",
+    ]
+    assert CORS_ALLOW_METHODS == ["GET", "POST", "PUT"]
+    assert CORS_ALLOW_HEADERS == ["Content-Type", "Authorization"]
+    assert CORS_ALLOW_CREDENTIALS is False

--- a/src/backend/tests/test_main.py
+++ b/src/backend/tests/test_main.py
@@ -1,0 +1,250 @@
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+import os
+import csv
+from unittest import mock
+
+# Import the FastAPI app and models from the proper package path
+from backend.main import app
+from backend.models import StudySessionCreate
+from backend.storage import save_session
+
+# Import the storage module itself
+import backend.storage as storage_module
+
+# Define the path for a temporary test data file using relative paths
+TEST_DATA_FILE = os.path.join(os.path.dirname(__file__), "test_sessions.csv")
+
+
+@pytest.fixture(scope="session", autouse=True)
+def setup_test_environment():
+    """Fixture to set up the test environment before any tests run."""
+    # Ensure the test data directory exists
+    os.makedirs(os.path.dirname(TEST_DATA_FILE), exist_ok=True)
+
+    # Ensure the test data file does not exist before tests
+    if os.path.exists(TEST_DATA_FILE):
+        os.remove(TEST_DATA_FILE)
+    # Override the SESSIONS_FILE path in the storage module for testing
+    storage_module.SESSIONS_FILE = TEST_DATA_FILE  # Use the imported module alias
+    yield
+    # Clean up the test data file after all tests run
+    if os.path.exists(TEST_DATA_FILE):
+        os.remove(TEST_DATA_FILE)
+
+
+@pytest_asyncio.fixture(scope="function")
+async def client():
+    """Provides an async test client for the FastAPI app."""
+    # Use ASGITransport instead of direct app parameter - newer httpx client syntax
+    from httpx import ASGITransport
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client
+
+
+@pytest.fixture(scope="function", autouse=True)
+def reset_test_data():
+    """Fixture to reset the test data file before each test function."""
+    if os.path.exists(TEST_DATA_FILE):
+        os.remove(TEST_DATA_FILE)
+
+    # Create an empty file with headers using CSV, similar to how the main app does it
+    with open(TEST_DATA_FILE, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=["id", "timestamp", "minutes", "tag"])
+        writer.writeheader()
+
+
+@pytest.mark.asyncio
+async def test_root(client: AsyncClient):
+    """Test the root endpoint."""
+    response = await client.get("/")
+    assert response.status_code == 200
+    assert response.json() == {"message": "DevOps Study Tracker API"}
+
+
+@pytest.mark.asyncio
+async def test_create_session(client: AsyncClient):
+    """Test creating a new study session."""
+    session_data = {"minutes": 30, "tag": "AWS"}
+    response = await client.post("/sessions", json=session_data)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["minutes"] == 30
+    assert data["tag"] == "AWS"
+    assert "id" in data
+    assert "timestamp" in data
+
+    # Verify data was saved using CSV
+    with open(TEST_DATA_FILE, "r", newline="") as f:
+        reader = list(csv.DictReader(f))
+        assert len(reader) == 1
+        assert int(reader[0]["minutes"]) == 30
+        assert reader[0]["tag"] == "AWS"
+
+
+@pytest.mark.asyncio
+async def test_read_sessions_empty(client: AsyncClient):
+    """Test reading sessions when none exist."""
+    response = await client.get("/sessions")
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+@pytest.mark.asyncio
+async def test_read_sessions_all(client: AsyncClient):
+    """Test reading all sessions."""
+    # Create some sessions first using the storage function directly for setup
+    save_session(
+        StudySessionCreate(minutes=25, tag="Kubernetes")
+    )  # Use imported save_session
+    save_session(StudySessionCreate(minutes=50, tag="AWS"))  # Use imported save_session
+
+    response = await client.get("/sessions")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 2
+    assert data[0]["tag"] == "Kubernetes"
+    assert data[1]["tag"] == "AWS"
+
+
+@pytest.mark.asyncio
+async def test_read_sessions_by_tag(client: AsyncClient):
+    """Test reading sessions filtered by tag."""
+    save_session(
+        StudySessionCreate(minutes=25, tag="Kubernetes")
+    )  # Use imported save_session
+    save_session(StudySessionCreate(minutes=50, tag="AWS"))  # Use imported save_session
+    save_session(
+        StudySessionCreate(minutes=15, tag="Kubernetes")
+    )  # Use imported save_session
+
+    response = await client.get("/sessions?tag=Kubernetes")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 2
+    assert all(item["tag"] == "Kubernetes" for item in data)
+
+    response = await client.get("/sessions?tag=AWS")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["tag"] == "AWS"
+
+    response = await client.get("/sessions?tag=NonExistent")
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+@pytest.mark.asyncio
+async def test_read_stats(client: AsyncClient):
+    """Test reading statistics."""
+    save_session(
+        StudySessionCreate(minutes=25, tag="Kubernetes")
+    )  # Use imported save_session
+    save_session(StudySessionCreate(minutes=50, tag="AWS"))  # Use imported save_session
+    save_session(
+        StudySessionCreate(minutes=15, tag="Kubernetes")
+    )  # Use imported save_session
+
+    response = await client.get("/stats")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total_sessions"] == 3
+    assert data["total_time"] == 90  # 25 + 50 + 15
+    assert "time_by_tag" in data
+    assert data["sessions_by_tag"]["Kubernetes"] == 2
+    assert data["sessions_by_tag"]["AWS"] == 1
+
+
+@pytest.mark.asyncio
+async def test_read_stats_empty(client: AsyncClient):
+    """Test reading statistics when no sessions exist."""
+    response = await client.get("/stats")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total_sessions"] == 0
+    assert data["total_time"] == 0
+    assert data["time_by_tag"] == {}
+    assert data["sessions_by_tag"] == {}
+
+
+@pytest.mark.asyncio
+async def test_error_handling_create_session(client: AsyncClient, monkeypatch):
+    """Test error handling in create_session endpoint."""
+
+    # Mock save_session to raise an exception
+    def mock_save_session(*args, **kwargs):
+        raise Exception("Test error")
+
+    monkeypatch.setattr("backend.main.save_session", mock_save_session)
+
+    session_data = {"minutes": 30, "tag": "AWS"}
+    response = await client.post("/sessions", json=session_data)
+    assert response.status_code == 500
+    assert "Error creating session" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_error_handling_read_sessions(client: AsyncClient, monkeypatch):
+    """Test error handling in read_sessions endpoint."""
+
+    # Mock get_all_sessions to raise an exception
+    def mock_get_all_sessions(*args, **kwargs):
+        raise Exception("Test error")
+
+    monkeypatch.setattr("backend.main.get_all_sessions", mock_get_all_sessions)
+
+    response = await client.get("/sessions")
+    assert response.status_code == 500
+    assert "Error fetching sessions" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_error_handling_read_sessions_by_tag(client: AsyncClient, monkeypatch):
+    """Test error handling in read_sessions endpoint with tag filter."""
+
+    # Mock get_sessions_by_tag to raise an exception
+    def mock_get_sessions_by_tag(*args, **kwargs):
+        raise Exception("Test error")
+
+    monkeypatch.setattr("backend.main.get_sessions_by_tag", mock_get_sessions_by_tag)
+
+    response = await client.get("/sessions?tag=AWS")
+    assert response.status_code == 500
+    assert "Error fetching sessions" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_error_handling_read_stats(client: AsyncClient, monkeypatch):
+    """Test error handling in read_stats endpoint."""
+
+    # Mock get_statistics to raise an exception
+    def mock_get_statistics(*args, **kwargs):
+        raise Exception("Test error")
+
+    monkeypatch.setattr("backend.main.get_statistics", mock_get_statistics)
+
+    response = await client.get("/stats")
+    assert response.status_code == 500
+    assert "Error fetching statistics" in response.json()["detail"]
+
+
+# Test for the main function
+def test_main_function(monkeypatch):
+    """Test the main() function that starts the uvicorn server."""
+    # Mock uvicorn.run to prevent actually starting the server
+    mock_run = mock.Mock()
+    monkeypatch.setattr("uvicorn.run", mock_run)
+
+    # Call the main function
+    from backend.main import main
+
+    main()
+
+    # Check that uvicorn.run was called with the expected arguments
+    mock_run.assert_called_once_with(
+        "backend.main:app", host="0.0.0.0", port=22112, reload=True
+    )

--- a/src/backend/tests/test_storage.py
+++ b/src/backend/tests/test_storage.py
@@ -1,0 +1,195 @@
+import pytest
+from datetime import datetime
+import os
+import uuid
+import csv
+
+# Import functions and variables from storage.py using new package structure
+from backend.storage import (
+    save_session,
+    get_all_sessions,
+    get_sessions_by_tag,
+    get_statistics,
+)
+from backend.models import StudySessionCreate, StudySession
+
+# Import the storage module itself
+import backend.storage as storage_module
+
+
+# Define the path for a temporary test data file using relative paths
+TEST_DATA_FILE = os.path.join(os.path.dirname(__file__), "test_storage_sessions.csv")
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_test_data_file():
+    """Fixture to set up the test data file path for the storage module tests."""
+    # Ensure the test data directory exists
+    os.makedirs(os.path.dirname(TEST_DATA_FILE), exist_ok=True)
+
+    original_data_file = storage_module.SESSIONS_FILE  # Use alias
+    # Override the SESSIONS_FILE path in the storage module for testing
+    storage_module.SESSIONS_FILE = TEST_DATA_FILE  # Use alias
+    yield
+    # Restore the original data file path and clean up
+    storage_module.SESSIONS_FILE = original_data_file  # Use alias
+    if os.path.exists(TEST_DATA_FILE):
+        os.remove(TEST_DATA_FILE)
+
+
+@pytest.fixture(scope="function", autouse=True)
+def reset_test_data():
+    """Fixture to reset the test data file before each test function."""
+    if os.path.exists(TEST_DATA_FILE):
+        os.remove(TEST_DATA_FILE)
+    # Create an empty file with headers using CSV
+    with open(TEST_DATA_FILE, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=["id", "timestamp", "minutes", "tag"])
+        writer.writeheader()
+
+
+def test_save_session():
+    """Test saving a single session."""
+    session_create = StudySessionCreate(minutes=45, tag="Terraform")
+    saved_session = save_session(session_create)
+
+    assert isinstance(saved_session, StudySession)
+    assert saved_session.minutes == 45
+    assert saved_session.tag == "Terraform"
+    assert isinstance(saved_session.id, str)  # ID is stored as string in the model
+    assert uuid.UUID(saved_session.id)  # Verify it's a valid UUID string
+    assert isinstance(saved_session.timestamp, datetime)
+
+    # Verify with CSV reader
+    with open(TEST_DATA_FILE, "r", newline="") as f:
+        reader = list(csv.DictReader(f))
+        assert len(reader) == 1
+        assert int(reader[0]["minutes"]) == 45
+        assert reader[0]["tag"] == "Terraform"
+        assert saved_session.id == reader[0]["id"]  # Compare as strings
+
+
+def test_save_multiple_sessions():
+    """Test saving multiple sessions sequentially."""
+    save_session(StudySessionCreate(minutes=30, tag="Docker"))
+    save_session(StudySessionCreate(minutes=60, tag="Python"))
+
+    with open(TEST_DATA_FILE, "r", newline="") as f:
+        reader = list(csv.DictReader(f))
+        assert len(reader) == 2
+        assert reader[0]["tag"] == "Docker"
+        assert reader[1]["tag"] == "Python"
+
+
+def test_get_all_sessions():
+    """Test retrieving all sessions."""
+    save_session(StudySessionCreate(minutes=20, tag="Git"))
+    save_session(StudySessionCreate(minutes=40, tag="CI/CD"))
+
+    sessions = get_all_sessions()
+    assert len(sessions) == 2
+    assert isinstance(sessions[0], StudySession)
+    assert sessions[0].tag == "Git"
+    assert sessions[1].tag == "CI/CD"
+
+
+def test_get_all_sessions_empty():
+    """Test retrieving all sessions when none exist."""
+    sessions = get_all_sessions()
+    assert sessions == []
+
+
+def test_get_sessions_by_tag():
+    """Test retrieving sessions filtered by tag."""
+    save_session(StudySessionCreate(minutes=25, tag="AWS"))
+    save_session(StudySessionCreate(minutes=55, tag="Azure"))
+    save_session(StudySessionCreate(minutes=35, tag="AWS"))
+
+    aws_sessions = get_sessions_by_tag("AWS")
+    assert len(aws_sessions) == 2
+    assert all(s.tag == "AWS" for s in aws_sessions)
+
+    azure_sessions = get_sessions_by_tag("Azure")
+    assert len(azure_sessions) == 1
+    assert azure_sessions[0].tag == "Azure"
+
+    gcp_sessions = get_sessions_by_tag("GCP")
+    assert gcp_sessions == []
+
+
+def test_get_statistics():
+    """Test calculating statistics."""
+    save_session(StudySessionCreate(minutes=10, tag="Linux"))
+    save_session(StudySessionCreate(minutes=20, tag="Networking"))
+    save_session(StudySessionCreate(minutes=30, tag="Linux"))
+
+    stats = get_statistics()
+    assert stats.total_sessions == 3
+    assert stats.total_time == 60  # 10 + 20 + 30
+    # Calculate average manually if needed
+    average_minutes = stats.total_time / stats.total_sessions
+    assert average_minutes == 20.0
+    assert stats.sessions_by_tag == {"Linux": 2, "Networking": 1}
+
+
+def test_get_statistics_empty():
+    """Test calculating statistics when no sessions exist."""
+    stats = get_statistics()
+    assert stats.total_sessions == 0
+    assert stats.total_time == 0
+    # Can't calculate average with zero sessions
+    assert stats.time_by_tag == {}
+    assert stats.sessions_by_tag == {}
+
+
+def test_create_and_read_sessions():
+    """Test creating sessions and then reading them back."""
+    # Create test CSV file with two sessions
+    with open(TEST_DATA_FILE, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=["id", "timestamp", "minutes", "tag"])
+        writer.writeheader()
+        writer.writerow(
+            {
+                "id": str(uuid.uuid4()),
+                "timestamp": datetime.now().isoformat(),
+                "minutes": 15,
+                "tag": "TestTag1",
+            }
+        )
+        writer.writerow(
+            {
+                "id": str(uuid.uuid4()),
+                "timestamp": datetime.now().isoformat(),
+                "minutes": 45,
+                "tag": "TestTag2",
+            }
+        )
+
+    # Read sessions
+    sessions = get_all_sessions()
+    assert len(sessions) == 2
+    assert sessions[0].tag == "TestTag1"
+    assert sessions[1].minutes == 45
+
+
+def test_file_not_exists_handling():
+    """Test handling when the data file doesn't exist."""
+    # Rename the test file temporarily
+    if os.path.exists(TEST_DATA_FILE):
+        os.rename(TEST_DATA_FILE, f"{TEST_DATA_FILE}.bak")
+
+    try:
+        # This should create the data file
+        sessions = get_all_sessions()
+        assert sessions == []
+
+        # Verify the file was created with headers
+        with open(TEST_DATA_FILE, "r", newline="") as f:
+            content = f.read()
+            assert "id,timestamp,minutes,tag" in content
+    finally:
+        # Restore the original file if it existed
+        if os.path.exists(f"{TEST_DATA_FILE}.bak"):
+            if os.path.exists(TEST_DATA_FILE):
+                os.remove(TEST_DATA_FILE)
+            os.rename(f"{TEST_DATA_FILE}.bak", TEST_DATA_FILE)

--- a/src/backend/uv.lock
+++ b/src/backend/uv.lock
@@ -115,6 +115,33 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/2d/02d4312c973c6050a18b314a5ad0b3210edb65a906f868e31c111dede4a6/pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1", size = 67955, upload-time = "2024-04-20T21:34:42.531Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669", size = 20556, upload-time = "2024-04-20T21:34:40.434Z" },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.11.4"
 source = { registry = "https://pypi.org/simple" }
@@ -155,6 +182,33 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/7d/e09391c2eebeab681df2b74bfe6c43422fffede8dc74187b2b0bf6fd7571/pydantic_core-2.33.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:61c18fba8e5e9db3ab908620af374db0ac1baa69f0f32df4f61ae23f15e586ac", size = 1806162, upload-time = "2025-04-23T18:32:20.188Z" },
     { url = "https://files.pythonhosted.org/packages/f1/3d/847b6b1fed9f8ed3bb95a9ad04fbd0b212e832d4f0f50ff4d9ee5a9f15cf/pydantic_core-2.33.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:95237e53bb015f67b63c91af7518a62a8660376a6a0db19b89acc77a4d6199f5", size = 1981560, upload-time = "2025-04-23T18:32:22.354Z" },
     { url = "https://files.pythonhosted.org/packages/6f/9a/e73262f6c6656262b5fdd723ad90f518f579b7bc8622e43a942eec53c938/pydantic_core-2.33.2-cp313-cp313t-win_amd64.whl", hash = "sha256:c2fc0a768ef76c15ab9238afa6da7f69895bb5d1ee83aeea2e3509af4472d0b9", size = 1935777, upload-time = "2025-04-23T18:32:25.088Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "8.3.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/3c/c9d525a414d506893f0cd8a8d0de7706446213181570cdbd766691164e40/pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845", size = 1450891, upload-time = "2025-03-02T12:54:54.503Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/3d/64ad57c803f1fa1e963a7946b6e0fea4a70df53c1a7fed304586539c2bac/pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820", size = 343634, upload-time = "2025-03-02T12:54:52.069Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "0.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8e/c4/453c52c659521066969523e87d85d54139bbd17b78f09532fb8eb8cdb58e/pytest_asyncio-0.26.0.tar.gz", hash = "sha256:c4df2a697648241ff39e7f0e4a73050b03f123f760673956cf0d72a4990e312f", size = 54156, upload-time = "2025-03-25T06:22:28.883Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/7f/338843f449ace853647ace35870874f69a764d251872ed1b4de9f234822c/pytest_asyncio-0.26.0-py3-none-any.whl", hash = "sha256:7b51ed894f4fbea1340262bdae5135797ebbe21d8638978e35d31c6d19f72fb0", size = 19694, upload-time = "2025-03-25T06:22:27.807Z" },
 ]
 
 [[package]]
@@ -210,6 +264,8 @@ source = { editable = "." }
 dependencies = [
     { name = "fastapi" },
     { name = "httpx" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "ruff" },
     { name = "uvicorn" },
 ]
@@ -218,6 +274,8 @@ dependencies = [
 requires-dist = [
     { name = "fastapi", specifier = ">=0.115.12" },
     { name = "httpx", specifier = ">=0.28.1" },
+    { name = "pytest", specifier = ">=8.3.5" },
+    { name = "pytest-asyncio", specifier = ">=0.26.0" },
     { name = "ruff", specifier = ">=0.11.8" },
     { name = "uvicorn", specifier = ">=0.34.2" },
 ]

--- a/src/backend/uv.lock
+++ b/src/backend/uv.lock
@@ -158,6 +158,31 @@ wheels = [
 ]
 
 [[package]]
+name = "ruff"
+version = "0.11.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/f6/adcf73711f31c9f5393862b4281c875a462d9f639f4ccdf69dc368311c20/ruff-0.11.8.tar.gz", hash = "sha256:6d742d10626f9004b781f4558154bb226620a7242080e11caeffab1a40e99df8", size = 4086399, upload-time = "2025-05-01T14:53:24.459Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/60/c6aa9062fa518a9f86cb0b85248245cddcd892a125ca00441df77d79ef88/ruff-0.11.8-py3-none-linux_armv6l.whl", hash = "sha256:896a37516c594805e34020c4a7546c8f8a234b679a7716a3f08197f38913e1a3", size = 10272473, upload-time = "2025-05-01T14:52:37.252Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/e4/0325e50d106dc87c00695f7bcd5044c6d252ed5120ebf423773e00270f50/ruff-0.11.8-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ab86d22d3d721a40dd3ecbb5e86ab03b2e053bc93c700dc68d1c3346b36ce835", size = 11040862, upload-time = "2025-05-01T14:52:41.022Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/27/b87ea1a7be37fef0adbc7fd987abbf90b6607d96aa3fc67e2c5b858e1e53/ruff-0.11.8-py3-none-macosx_11_0_arm64.whl", hash = "sha256:258f3585057508d317610e8a412788cf726efeefa2fec4dba4001d9e6f90d46c", size = 10385273, upload-time = "2025-05-01T14:52:43.551Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/f7/3346161570d789045ed47a86110183f6ac3af0e94e7fd682772d89f7f1a1/ruff-0.11.8-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:727d01702f7c30baed3fc3a34901a640001a2828c793525043c29f7614994a8c", size = 10578330, upload-time = "2025-05-01T14:52:45.48Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/c3/327fb950b4763c7b3784f91d3038ef10c13b2d42322d4ade5ce13a2f9edb/ruff-0.11.8-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3dca977cc4fc8f66e89900fa415ffe4dbc2e969da9d7a54bfca81a128c5ac219", size = 10122223, upload-time = "2025-05-01T14:52:47.675Z" },
+    { url = "https://files.pythonhosted.org/packages/de/c7/ba686bce9adfeb6c61cb1bbadc17d58110fe1d602f199d79d4c880170f19/ruff-0.11.8-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c657fa987d60b104d2be8b052d66da0a2a88f9bd1d66b2254333e84ea2720c7f", size = 11697353, upload-time = "2025-05-01T14:52:50.264Z" },
+    { url = "https://files.pythonhosted.org/packages/53/8e/a4fb4a1ddde3c59e73996bb3ac51844ff93384d533629434b1def7a336b0/ruff-0.11.8-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:f2e74b021d0de5eceb8bd32919f6ff8a9b40ee62ed97becd44993ae5b9949474", size = 12375936, upload-time = "2025-05-01T14:52:52.394Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/a1/9529cb1e2936e2479a51aeb011307e7229225df9ac64ae064d91ead54571/ruff-0.11.8-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f9b5ef39820abc0f2c62111f7045009e46b275f5b99d5e59dda113c39b7f4f38", size = 11850083, upload-time = "2025-05-01T14:52:55.424Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/94/8f7eac4c612673ae15a4ad2bc0ee62e03c68a2d4f458daae3de0e47c67ba/ruff-0.11.8-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c1dba3135ca503727aa4648152c0fa67c3b1385d3dc81c75cd8a229c4b2a1458", size = 14005834, upload-time = "2025-05-01T14:52:58.056Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/7c/6f63b46b2be870cbf3f54c9c4154d13fac4b8827f22fa05ac835c10835b2/ruff-0.11.8-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7f024d32e62faad0f76b2d6afd141b8c171515e4fb91ce9fd6464335c81244e5", size = 11503713, upload-time = "2025-05-01T14:53:01.244Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/91/57de411b544b5fe072779678986a021d87c3ee5b89551f2ca41200c5d643/ruff-0.11.8-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:d365618d3ad747432e1ae50d61775b78c055fee5936d77fb4d92c6f559741948", size = 10457182, upload-time = "2025-05-01T14:53:03.726Z" },
+    { url = "https://files.pythonhosted.org/packages/01/49/cfe73e0ce5ecdd3e6f1137bf1f1be03dcc819d1bfe5cff33deb40c5926db/ruff-0.11.8-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:4d9aaa91035bdf612c8ee7266153bcf16005c7c7e2f5878406911c92a31633cb", size = 10101027, upload-time = "2025-05-01T14:53:06.555Z" },
+    { url = "https://files.pythonhosted.org/packages/56/21/a5cfe47c62b3531675795f38a0ef1c52ff8de62eaddf370d46634391a3fb/ruff-0.11.8-py3-none-musllinux_1_2_i686.whl", hash = "sha256:0eba551324733efc76116d9f3a0d52946bc2751f0cd30661564117d6fd60897c", size = 11111298, upload-time = "2025-05-01T14:53:08.825Z" },
+    { url = "https://files.pythonhosted.org/packages/36/98/f76225f87e88f7cb669ae92c062b11c0a1e91f32705f829bd426f8e48b7b/ruff-0.11.8-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:161eb4cff5cfefdb6c9b8b3671d09f7def2f960cee33481dd898caf2bcd02304", size = 11566884, upload-time = "2025-05-01T14:53:11.626Z" },
+    { url = "https://files.pythonhosted.org/packages/de/7e/fff70b02e57852fda17bd43f99dda37b9bcf3e1af3d97c5834ff48d04715/ruff-0.11.8-py3-none-win32.whl", hash = "sha256:5b18caa297a786465cc511d7f8be19226acf9c0a1127e06e736cd4e1878c3ea2", size = 10451102, upload-time = "2025-05-01T14:53:14.303Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/a9/eaa571eb70648c9bde3120a1d5892597de57766e376b831b06e7c1e43945/ruff-0.11.8-py3-none-win_amd64.whl", hash = "sha256:6e70d11043bef637c5617297bdedec9632af15d53ac1e1ba29c448da9341b0c4", size = 11597410, upload-time = "2025-05-01T14:53:16.571Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/be/f6b790d6ae98f1f32c645f8540d5c96248b72343b0a56fab3a07f2941897/ruff-0.11.8-py3-none-win_arm64.whl", hash = "sha256:304432e4c4a792e3da85b7699feb3426a0908ab98bf29df22a31b0cdd098fac2", size = 10713129, upload-time = "2025-05-01T14:53:22.27Z" },
+]
+
+[[package]]
 name = "sniffio"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -185,6 +210,7 @@ source = { editable = "." }
 dependencies = [
     { name = "fastapi" },
     { name = "httpx" },
+    { name = "ruff" },
     { name = "uvicorn" },
 ]
 
@@ -192,6 +218,7 @@ dependencies = [
 requires-dist = [
     { name = "fastapi", specifier = ">=0.115.12" },
     { name = "httpx", specifier = ">=0.28.1" },
+    { name = "ruff", specifier = ">=0.11.8" },
     { name = "uvicorn", specifier = ">=0.34.2" },
 ]
 


### PR DESCRIPTION
This pull request introduces a new CI workflow for backend tests, integrates the Ruff linter and formatter into the development process, and updates the project dependencies. Below are the most important changes grouped by theme:

### CI Workflow Enhancements:
* Added a new GitHub Actions workflow in `.github/workflows/backend-tests.yaml` to run backend tests. The workflow includes a path filter to trigger only when relevant files are modified and steps for linting, formatting, and dependency installation using UV and Ruff.

### Linting and Formatting Integration:
* Updated `.pre-commit-config.yaml` to include hooks for Ruff linter and formatter, enabling pre-commit checks for code quality and formatting.

### Dependency Updates:
* Added `ruff` to the `mise.toml` configuration file to ensure it is installed as part of the project's tooling.