### PR TITLE
ci(gha): implement image scanning with trivy

### DIFF
--- a/.github/workflows/backend-tests.yaml
+++ b/.github/workflows/backend-tests.yaml
@@ -75,3 +75,17 @@ jobs:
           header: test-coverage
           recreate: true
           path: code-coverage-results.md
+
+      - name: Build Docker image
+        run: docker build -t backend-app:latest .
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@0.30.0
+        with:
+          image-ref: "backend-app:latest"
+          format: "table"
+          exit-code: "0"
+          # exit-code: '1' # Fail the workflow if vulnerabilities are found.
+          ignore-unfixed: true
+          vuln-type: "os,library"
+          severity: "CRITICAL,HIGH"

--- a/src/backend/Dockerfile
+++ b/src/backend/Dockerfile
@@ -16,7 +16,7 @@ COPY . /app
 
 # Sync the project and install it, now that we have access to the source code
 RUN --mount=type=cache,target=/root/.cache/uv \
-  uv sync --locked --no-editable
+  uv sync --locked --no-editable --no-dev
 
 FROM python:3.13-alpine
 

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -5,15 +5,7 @@ description = "Backend API for tracking study time for DevOps certifications"
 readme = "README.md"
 authors = [{ name = "Mischa van den Burg", email = "mischa@gmail.com" }]
 requires-python = ">=3.13"
-dependencies = [
-  "fastapi>=0.115.12",
-  "httpx>=0.28.1",
-  "pytest>=8.3.5",
-  "pytest-asyncio>=0.26.0",
-  "pytest-cov>=6.1.1",
-  "ruff>=0.11.8",
-  "uvicorn>=0.34.2",
-]
+dependencies = ["fastapi>=0.115.12", "httpx>=0.28.1", "uvicorn>=0.34.2"]
 
 [project.scripts]
 study-tracker-api = "backend.main:main"
@@ -28,3 +20,11 @@ packages = ["src/backend"]
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[dependency-groups]
+dev = [
+  "pytest>=8.3.5",
+  "pytest-asyncio>=0.26.0",
+  "pytest-cov>=6.1.1",
+  "ruff>=0.11.8",
+]

--- a/src/backend/uv.lock
+++ b/src/backend/uv.lock
@@ -306,22 +306,30 @@ source = { editable = "." }
 dependencies = [
     { name = "fastapi" },
     { name = "httpx" },
+    { name = "uvicorn" },
+]
+
+[package.dev-dependencies]
+dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "ruff" },
-    { name = "uvicorn" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "fastapi", specifier = ">=0.115.12" },
     { name = "httpx", specifier = ">=0.28.1" },
+    { name = "uvicorn", specifier = ">=0.34.2" },
+]
+
+[package.metadata.requires-dev]
+dev = [
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "pytest-asyncio", specifier = ">=0.26.0" },
     { name = "pytest-cov", specifier = ">=6.1.1" },
     { name = "ruff", specifier = ">=0.11.8" },
-    { name = "uvicorn", specifier = ">=0.34.2" },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request introduces several updates to improve the backend's dependency management, security, and workflow automation. Key changes include restructuring dependencies in `pyproject.toml`, adding a Docker image build and vulnerability scanning step to the CI workflow, and optimizing the Docker build process.

### Dependency management updates:
* [`src/backend/pyproject.toml`](diffhunk://#diff-3c0d9933efa94182a3acbfeec8f5b1075f72debdee61ca34232ad6421153b8d1R23-R30): Moved development dependencies (e.g., `pytest`, `ruff`) into a new `[dependency-groups]` section under `dev` for better separation of production and development dependencies.
* [`src/backend/pyproject.toml`](diffhunk://#diff-3c0d9933efa94182a3acbfeec8f5b1075f72debdee61ca34232ad6421153b8d1L8-R8): Removed development dependencies from the main `dependencies` array, leaving only production dependencies like `fastapi`, `httpx`, and `uvicorn`.

### CI workflow improvements:
* [`.github/workflows/backend-tests.yaml`](diffhunk://#diff-4e6100aeed12a55586e68fcd32ae167744b18737b3c86e1db8ceaf92ff98bc43R78-R91): Added a step to build a Docker image for the backend and integrated the Trivy vulnerability scanner to identify critical and high-severity vulnerabilities in the image.

### Docker build optimization:
* [`src/backend/Dockerfile`](diffhunk://#diff-bdd2a3406ba1977ea235c3c8ba6350e9d120f9cc7cc880686d8e198fcb367bddL19-R19): Updated the `uv sync` command to exclude development dependencies during the Docker build process by adding the `--no-dev` flag, reducing the image size and improving security.